### PR TITLE
Using redis naming convention ie: ":" separator

### DIFF
--- a/src/M6Web/Component/Redis/Cache.php
+++ b/src/M6Web/Component/Redis/Cache.php
@@ -60,7 +60,7 @@ class Cache extends Manager
      */
     public function setNamespace($v)
     {
-        $this->namespace =  str_replace(array('\\', '?', '*', '[', ']', ':'), '', (string) $v).'/';
+        $this->namespace =  str_replace(array('\\', '?', '*', '[', ']', ':'), '', (string) $v).':';
     }
 
     /**


### PR DESCRIPTION
La convention de nommage des clés pour redis utilise des ":" comme séparateur:
http://redis.io/topics/data-types-intro

Par ailleurs les outils de visualisation Redis utiliser le ':' pour construire leur arbre.

Est il possible possible de coller au standard redis?
