### PR TITLE
fix predis bc break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 7
   - 5.6
   - 5.5
-  - 5.4
 
 before_script:
   - phpenv config-rm xdebug.ini

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "predis/predis": "~1.0"
+        "predis/predis": "^1.1.1"
     },
     "require-dev": {
         "atoum/atoum": "@stable",

--- a/src/M6Web/Component/Redis/Cache.php
+++ b/src/M6Web/Component/Redis/Cache.php
@@ -194,7 +194,7 @@ class Cache extends Manager
         $ret = $this->getRedis($key)->exists($this->getPatternKey().$key);
         $this->notifyEvent('exists', array($this->getPatternKey().$key), microtime(true) - $start);
 
-        return $ret;
+        return (boolean) $ret;
     }
 
     /**

--- a/tests/M6Web/Component/Redis/DB.php
+++ b/tests/M6Web/Component/Redis/DB.php
@@ -270,15 +270,15 @@ class DB extends atoum\test
         $this->array($redis->hkeys($cacheKey))->IsIdenticalTo(array('title', 'lastUpdate'));
 
         //Est ce que une clé particuliere existe
-        $this->boolean($redis->hexists($cacheKey, 'title'))->isIdenticalTo(true);
-        $this->boolean($redis->hexists($cacheKey, 'titleee'))->isIdenticalTo(false);
+        $this->integer($redis->hexists($cacheKey, 'title'))->isIdenticalTo(1);
+        $this->integer($redis->hexists($cacheKey, 'titleee'))->isIdenticalTo(0);
 
         //Suppression d'un clé du tableau
         $redis->hdel($cacheKey, 'title');
 
         //La clé a-t-elle bien été supprimé
-        $this->boolean($redis->hexists($cacheKey, 'title'))->isIdenticalTo(false);
-        $this->boolean($redis->hexists($cacheKey, 'lastUpdate'))->isIdenticalTo(true);
+        $this->integer($redis->hexists($cacheKey, 'title'))->isIdenticalTo(0);
+        $this->integer($redis->hexists($cacheKey, 'lastUpdate'))->isIdenticalTo(1);
         $this->integer(count($redis->hgetall($cacheKey)))->isIdenticalTo(1);
 
         $redis->hkeys($cacheKey);


### PR DESCRIPTION
🐛 predis 1.1.1 return now 0 for false and 1 for true (like redis do) in exists and hexists. 